### PR TITLE
Täsmennä log-asteikon subtitlea

### DIFF
--- a/vignettes/main.qmd
+++ b/vignettes/main.qmd
@@ -657,7 +657,7 @@ dat_gva_ind|>
   the_title_blank("xyl") +
   labs(
     title = "Arvonlisä / työtunnit",
-    subtitle = "Vuoden 2017 $, ostovoimakorjattuna, logaritminen asteikko",
+    subtitle = "Vuoden 2017 $, ostovoimakorjattuna, logaritminen asteikko, log-asteikko",
     caption = "Lähde: OECD, GGDC, Tuottavuuslautakunta"
   )
 


### PR DESCRIPTION
### Motivation
- Selkeyttää logaritmista kuvaajaa lisäämällä tarkentavan tekstin subtitleen, jotta lukija ymmärtää että kuvaaja käyttää log-asteikkoa.

### Description
- Lisätty `, log-asteikko` `vignettes/main.qmd` tiedostossa olevaan kuvaajan `subtitle`-kenttään kohdassa, jossa käytetään `scale_y_log10`.

### Testing
- Ei ajettu automaattisia testejä, koska muutos on tekstiin (vignette-subtitle) liittyvä ja ei vaikuta koodin toiminnallisuuteen.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105c99e35c832589cd6d853ccd399f)