### PR TITLE
Fix devtools::check errors in check_factor_levels and oecd_clean_data

### DIFF
--- a/R/oecd_funs.R
+++ b/R/oecd_funs.R
@@ -25,7 +25,20 @@ utils::globalVariables(c(
 #' cleaned <- oecd_clean_data(smdx_data, vars = vars, freq = "A")
 #' }
 #' @export
-oecd_clean_data <- function(df, drop_vars = NULL, vars = c(), freq = "A") {
+oecd_clean_data <- function(df = NULL, sdmx_obj = NULL, drop_vars = NULL, vars = c(), freq = "A") {
+
+
+  # Backward compatibility: allow passing an SDMX object via `sdmx_obj`
+  if (!is.null(sdmx_obj)) {
+    if (!is.null(df)) {
+      warning("Both `df` and `sdmx_obj` were supplied; using `sdmx_obj`.")
+    }
+    df <- as.data.frame(sdmx_obj)
+  }
+
+  if (is.null(df)) {
+    stop("Provide either `df` or `sdmx_obj`.")
+  }
 
   # Validate 'vars' is named (or empty)
   if (length(vars) > 0) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -42,7 +42,7 @@ check_factor_levels <- function(df, drop_vars = character()) {
 
   # Select factor variables, excluding drop_vars
   factor_vars0 <- names(df)[vapply(df, is.factor, logical(1))]
-  factor_vars <- setdiff(factor_vars, drop_vars)
+  factor_vars <- setdiff(factor_vars0, drop_vars)
 
   if (length(factor_vars) == 0) {
     warning("No factor variables to tabulate after applying drop_vars.")


### PR DESCRIPTION
### Motivation
- `R CMD check` was failing because `check_factor_levels()` crashed in examples with `object 'factor_vars' not found` causing example errors.
- Tests were failing because callers use `sdmx_obj = ...` but `oecd_clean_data()` did not accept that argument producing an `unused argument` error. 

### Description
- In `R/utils.R` fixed the factor-selection bug by changing `factor_vars <- setdiff(factor_vars0, drop_vars)` so `drop_vars` is applied to the correct variable list.
- In `R/oecd_funs.R` added a backward-compatible `sdmx_obj` parameter to `oecd_clean_data()` and convert it to a data frame when supplied.
- Added a warning if both `df` and `sdmx_obj` are supplied and an error if neither is provided to ensure callers pass one input. 

### Testing
- I attempted to run the package tests with `devtools::test(filter='oecd_clean|check_factor_levels')` but the environment does not have `R` (`R: command not found`), so automated tests could not be executed here.
- The changes were committed locally (commit message: `Fix check errors in factor tabulation and OECD cleaner args`) and a PR description was created via `make_pr`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a141c99038083259bce629f8bd8067c)